### PR TITLE
nautible/issues#1

### DIFF
--- a/service-mesh/README.md
+++ b/service-mesh/README.md
@@ -79,6 +79,29 @@ $ helm install istiod manifests/charts/istio-control/istio-discovery \
 ※ AWS環境のIngressのHelmパラメータについて  
 AWS環境では、Istio Ingressの前段にAWS LoadBalancer Controllerを配置するため、Ingressの種類をNordPortに変更し、ヘルスチェック用ポートの固定化設定を行っています。
 
+### 2-3. Argocdマニフェストのデプロイ
+
+AWS
+```bash
+kubectl apply -f service-mesh/overlays/aws/application.yaml
+```
+
+Azure  
+kustomizeのpatchで環境個別の設定が必要な値を定義する  
+service-mesh/overlays/azure/kustomization.yaml
+
+```yaml
+    # Azure frontdoorのidを設定する
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/when/0/values
+        value: ["f294b480-a3a9-45c9-86c0-e646fce7a8aa"]
+```
+マニフェストを適用する
+```bash
+kubectl apply -f service-mesh/overlays/azure/application.yaml
+```
+
 ## 3. Traffic management (トラフィック管理)
 
 　以下の機能を提供します。詳細は [公式ドキュメント](https://istio.io/latest/docs/) を参照してください。

--- a/service-mesh/overlays/azure/application.yaml
+++ b/service-mesh/overlays/azure/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: service-mesh/overlays/azure
     repoURL: https://github.com/nautible/nautible-plugin
-    targetRevision: develop
+    targetRevision: feature/issue1
   syncPolicy:
     automated:
       prune: true

--- a/service-mesh/overlays/azure/kustomization.yaml
+++ b/service-mesh/overlays/azure/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
-# 外部公開しないように一旦
+resources:
+  - validate-fdid.yaml
 patchesJson6902:
+  # Frontdoorからのアクセスのみ許容するようにIstioのIngressGetewayにservice-tagsを定義する
   - target:
       version: v1alpha1
       kind: Application
@@ -11,29 +13,14 @@ patchesJson6902:
     patch: |-
       - op: add
         path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.type", "value": "ClusterIP"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[1].port", "value": "80"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[1].targetPort", "value": "8080"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[1].name", "value": "http2"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[1].protocol", "value": "TCP"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[0].port", "value": "443"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[0].targetPort", "value": "8443"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[0].name", "value": "https"}
-      - op: add
-        path: /spec/source/helm/parameters/0
-        value: {"name": "gateways.istio-ingressgateway.ports[0].protocol", "value": "TCP"}
-
+        value: {'name': 'gateways.istio-ingressgateway.serviceAnnotations.service\.beta\.kubernetes\.io/azure-allowed-service-tags', 'value': 'AzureFrontDoor.BackEnd'}
+  - target:
+      group: security.istio.io
+      version: v1beta1
+      kind: AuthorizationPolicy
+      name: validate-fdid
+    # Azure frontdoorのidを設定する。IstioのAuthorizationPolicyでヘッダーのfrontdoorのidを検証し、Frontdoorからのアクセスのみ許容する。
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/when/0/values
+        value: ["f294b480-a3a9-45c9-86c0-e646fce7a8aa"]

--- a/service-mesh/overlays/azure/validate-fdid.yaml
+++ b/service-mesh/overlays/azure/validate-fdid.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: validate-fdid
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: istio-ingressgateway
+  rules:
+  - to:
+    when:
+    - key: request.headers[X-Azure-FDID]
+      values: ["00000000-0000-0000-0000-000000000000"]


### PR DESCRIPTION
LBへのアクセスをFrontDoorからのみ可能になるよう制限を追加。その結果、ロードバランサーのSSL化は不要となった。
