### PR TITLE
fix ignore keycloak auth policy

### DIFF
--- a/service-mesh/overlays/azure/application.yaml
+++ b/service-mesh/overlays/azure/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: service-mesh/overlays/azure
     repoURL: https://github.com/nautible/nautible-plugin
-    targetRevision: develop
+    targetRevision: feature/ignore-auth-policy
   syncPolicy:
     automated:
       prune: true

--- a/service-mesh/overlays/azure/kustomization.yaml
+++ b/service-mesh/overlays/azure/kustomization.yaml
@@ -22,5 +22,5 @@ patchesJson6902:
     # Azure frontdoorのidを設定する。IstioのAuthorizationPolicyでヘッダーのfrontdoorのidを検証し、Frontdoorからのアクセスのみ許容する。
     patch: |-
       - op: replace
-        path: /spec/rules/0/when/0/values
+        path: /spec/rules/0/when/0/notValues
         value: ["f294b480-a3a9-45c9-86c0-e646fce7a8aa"]

--- a/service-mesh/overlays/azure/validate-fdid.yaml
+++ b/service-mesh/overlays/azure/validate-fdid.yaml
@@ -4,6 +4,7 @@ metadata:
   name: validate-fdid
   namespace: istio-system
 spec:
+  action: DENY
   selector:
     matchLabels:
       app: istio-ingressgateway
@@ -11,4 +12,4 @@ spec:
   - to:
     when:
     - key: request.headers[X-Azure-FDID]
-      values: ["00000000-0000-0000-0000-000000000000"]
+      notValues: ["00000000-0000-0000-0000-000000000000"]


### PR DESCRIPTION
Actionを判定方法を逆転し、actionをDenyに変更。
Authorization PolicyはAllowあっても、Denyが一つでもあると、必ずブロックするため。
