### PR TITLE
nautible/issues#115

### DIFF
--- a/metrics-server/manifests/components.yaml
+++ b/metrics-server/manifests/components.yaml
@@ -133,7 +133,7 @@ spec:
         - --secure-port=4443
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
+        image: registry.k8s.io/metrics-server/metrics-server:v0.4.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/observation/prometheus-operator/manifests/kube-state-metrics-deployment.yaml
+++ b/observation/prometheus-operator/manifests/kube-state-metrics-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.1
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.1
         name: kube-state-metrics
         resources:
           limits:

--- a/observation/prometheus-operator/manifests/prometheus-adapter-deployment.yaml
+++ b/observation/prometheus-operator/manifests/prometheus-adapter-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
-        image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.0
+        image: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
         name: prometheus-adapter
         ports:
         - containerPort: 6443


### PR DESCRIPTION
k8s.gcr.ioが2023/4に停止されるため、参照しているマニフェストはregistry.k8s.ioに変更する。
