### PR TITLE
エコシステムのバージョンアップ

### DIFF
--- a/albc/application.yaml
+++ b/albc/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://aws.github.io/eks-charts/'
-    targetRevision: 1.4.1
+    targetRevision: 1.6.2
     chart: 'aws-load-balancer-controller'
     helm:
       parameters:

--- a/albc/ingress/manifest/ingress.yaml
+++ b/albc/ingress/manifest/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: nautible-alb-ingress
     alb.ingress.kubernetes.io/healthcheck-port: '31234'
     alb.ingress.kubernetes.io/healthcheck-path: '/healthz/ready'
-    alb.ingress.kubernetes.io/security-groups: 'nautible-dev-cluster-v1_27-albc-sg' # 対象のセキュリティグループに変更する。idまたは名称を指定する。
+    alb.ingress.kubernetes.io/security-groups: 'nautible-dev-cluster-v1_28-albc-sg' # 対象のセキュリティグループに変更する。idまたは名称を指定する。
 spec:
   rules:
     - 

--- a/albc/ingress/manifest/ingress.yaml
+++ b/albc/ingress/manifest/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: nautible-alb-ingress
     alb.ingress.kubernetes.io/healthcheck-port: '31234'
     alb.ingress.kubernetes.io/healthcheck-path: '/healthz/ready'
-    alb.ingress.kubernetes.io/security-groups: 'nautible-dev-cluster-v1_28-albc-sg' # 対象のセキュリティグループに変更する。idまたは名称を指定する。
+    alb.ingress.kubernetes.io/security-groups: 'nautible-dev-cluster-albc-sg' # 対象のセキュリティグループに変更する。idまたは名称を指定する。
 spec:
   rules:
     - 

--- a/cluster-autoscaler/application.yaml
+++ b/cluster-autoscaler/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://kubernetes.github.io/autoscaler/'
-    targetRevision: 9.29.1
+    targetRevision: 9.34.0
     chart: cluster-autoscaler
     helm:
       parameters:

--- a/distributed-application/application.yaml
+++ b/distributed-application/application.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://dapr.github.io/helm-charts/'
-    targetRevision: 1.10.4
+    targetRevision: 1.12.2
     chart: dapr
     helm:
       parameters:


### PR DESCRIPTION
EKS v1.28に変更する際に再デプロイ等をする必要があったエコシステムだけとりあえず最新にバージョンアップ。
※albc/ingress/manifest/ingress.yamlは前回デフォルト値にv1_27を入れたが、デフォルトはnautible-dev-clusterのままがいい気がするので戻しただけです。

他のエコシステムのバージョンアップもあるのでいったんできた分だけマージするだけで、関連Issueはまだクローズしません。