### PR TITLE
v1.12.2 -> v1.12.5

### DIFF
--- a/distributed-application/README.md
+++ b/distributed-application/README.md
@@ -4,9 +4,9 @@
 
 分散アプリケーションランタイム[Dapr](https://dapr.io/)を導入し、分散アプリケーションの構築をサポートする機能を提供する。
 
-### 開発Tips
+### 開発 Tips
 
-Daprを利用する際の開発Tipsは[こちら](https://github.com/nautible/docs/tree/main/reference/dapr)を参照
+Dapr を利用する際の開発 Tips は[こちら](https://github.com/nautible/docs/tree/main/reference/dapr)を参照
 
 ## 2. 導入
 
@@ -19,7 +19,6 @@ $ kubectl apply -f distributed-application/application.yaml
 ```
 $ kubectl get deploy -n dapr-system
 NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
-dapr-dashboard          1/1     1            1           18d
 dapr-operator           1/1     1            1           18d
 dapr-sentry             1/1     1            1           18d
 dapr-sidecar-injector   1/1     1            1           18d
@@ -27,6 +26,10 @@ dapr-sidecar-injector   1/1     1            1           18d
 
 ## 4. 削除
 
+ArgoCD のコンソール画面より Dapr の削除を行う。
+
+コマンドラインによる削除を行う場合は、Argo CD CLI を使用して Application リソースを削除する。
+
 ```
-$ kubectl delete -f distributed-application/application.yaml
+argocd app delete argocd/dapr
 ```

--- a/distributed-application/application.yaml
+++ b/distributed-application/application.yaml
@@ -11,25 +11,25 @@ spec:
   source:
     path: ''
     repoURL: 'https://dapr.github.io/helm-charts/'
-    targetRevision: 1.12.2
+    targetRevision: 1.12.5
     chart: dapr
     helm:
       parameters:
-      - name: "dapr_sidecar_injector.allowedServiceAccounts"
-        value: "argowf:argo-workflows-workflow-controller"
+        - name: 'dapr_sidecar_injector.allowedServiceAccounts'
+          value: 'argowf:argo-workflows-workflow-controller'
   ignoreDifferences:
-  - group: apps
-    kind: Secret
-    name: dapr-trust-bundle
-    namespace: dapr-system 
-    jsonPointers:
-    - /metadata/labels # デプロイ後に動的にラベル付与されるため差分を無視する
-  - group: apiextensions.k8s.io
-    kind: CustomResourceDefinition
-    name: subscriptions.dapr.io
-    namespace: dapr-system 
-    jsonPointers:
-    - /spec/conversion/webhook/clientConfig/service/namespace # デプロイ後に動的に変更されるため差分を無視する
+    - group: apps
+      kind: Secret
+      name: dapr-trust-bundle
+      namespace: dapr-system
+      jsonPointers:
+        - /metadata/labels # デプロイ後に動的にラベル付与されるため差分を無視する
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: subscriptions.dapr.io
+      namespace: dapr-system
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/service/namespace # デプロイ後に動的に変更されるため差分を無視する
   project: default
   syncPolicy:
     automated:


### PR DESCRIPTION
ドキュメント更新
- 削除手順修正
- v.1.11よりHELMのインストール対象からDashboardがなくなっているためドキュメントの確認手順に表示されていたDashboardPodを削除